### PR TITLE
Add project URL to manifest to be compatible with EC 3.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
     "display_name": "Scheduled Payments",
     "version": "1.0",
     "description": "This allows a user to specify recurring payments to a number of recipients.",
+    "project_url": "https://github.com/rt121212121/electron_cash_scheduled_payments_plugin",
     "minimum_ec_version": "3.2",
     "package_name": "scheduled_payments",
     "available_for": [


### PR DESCRIPTION
Apparently the manifest now needs a Project URL entry or the zip file won't load in EC 3.3. Please fix, and also update the zip file linked accordingly.